### PR TITLE
Add endpoint disabling feature

### DIFF
--- a/src/beatport-cli.ts
+++ b/src/beatport-cli.ts
@@ -168,11 +168,11 @@ function loadConfig(): BeatportMCPConfig {
     endpointPath: argv.path,
     includeTools: argv.tool as string[] | undefined,
     includeTags: argv.tag as string[] | undefined,
-    includeResources: argv.resource as string[] | undefined,
-    includeOperations: argv.operation as string[] | undefined,
-    toolsMode: argv.tools as "all" | "dynamic",
-    disableAbbreviation: argv["disable-abbreviation"],
-  }
+      includeResources: argv.resource as string[] | undefined,
+      includeOperations: argv.operation as string[] | undefined,
+      toolsMode: argv.tools as "all" | "dynamic",
+      disableAbbreviation: argv["disable-abbreviation"],
+    }
 
   console.error("✅ Configuration created successfully")
   return config


### PR DESCRIPTION
## Summary
- allow disabling endpoints in BeatportMCPServer
- expose new `--disable-endpoint` CLI flag
- document the new flag in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68403e9f3eec8323aa5d53f4643b9209